### PR TITLE
Shorten name to Dodger for consistency sake

### DIFF
--- a/asteroid-dodger.desktop
+++ b/asteroid-dodger.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=Asteroid Dodger
+Name=Dodger
 Exec=asteroid-dodger
 Icon=asteroid-dodger
 X-Asteroid-Needs-Repaint=true


### PR DESCRIPTION
Asteroid Blaster is Blaster. Asteroid Dodger is too long for many screens.